### PR TITLE
framework/Framework: stop the animator thread after user close the window

### DIFF
--- a/src/main/java/main/framework/Framework.java
+++ b/src/main/java/main/framework/Framework.java
@@ -9,10 +9,7 @@ import buffer.BufferUtils;
 import com.jogamp.newt.Display;
 import com.jogamp.newt.NewtFactory;
 import com.jogamp.newt.Screen;
-import com.jogamp.newt.event.KeyEvent;
-import com.jogamp.newt.event.KeyListener;
-import com.jogamp.newt.event.MouseEvent;
-import com.jogamp.newt.event.MouseListener;
+import com.jogamp.newt.event.*;
 import com.jogamp.newt.opengl.GLWindow;
 import com.jogamp.opengl.GL3;
 import com.jogamp.opengl.GLAutoDrawable;
@@ -81,6 +78,19 @@ public class Framework implements GLEventListener, KeyListener, MouseListener {
         animator = new Animator();
         animator.add(window);
         animator.start();
+
+        window.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowDestroyed(WindowEvent e) {
+                new Thread(new Runnable() {
+                    public void run() {
+                        //stop the animator thread when user close the window
+                        animator.stop();
+                        System.exit(0);
+                    }
+                }).start();
+            }
+        });
     }
 
     @Override
@@ -122,7 +132,6 @@ public class Framework implements GLEventListener, KeyListener, MouseListener {
 
     @Override
     public final void dispose(GLAutoDrawable drawable) {
-
         GL3 gl3 = drawable.getGL().getGL3();
 
         end(gl3);
@@ -131,8 +140,6 @@ public class Framework implements GLEventListener, KeyListener, MouseListener {
         BufferUtils.destroyDirectBuffer(clearDepth);
         BufferUtils.destroyDirectBuffer(matBuffer);
         BufferUtils.destroyDirectBuffer(vecBuffer);
-
-        System.exit(1);
     }
 
     protected void end(GL3 gl) {


### PR DESCRIPTION
This change fixes the warning seen on Linux systems caused by system exit before
JOGL have had the opportunity to properly closed the window after dispose.

X11Util.Display: Shutdown (JVM shutdown: true, open (no close attempt): 2/2, reusable (open, marked uncloseable): 0, pending (open in creation order): 2)
X11Util: Open X11 Display Connections: 2
X11Util: Open[0]: NamedX11Display[:0, 0x7f1f08004b30, refCount 1, unCloseable false]
X11Util: Open[1]: NamedX11Display[:0, 0x7f1f08017c80, refCount 1, unCloseable false]

Signed-off-by: Xerxes Rånby <xerxes@gudinna.com>